### PR TITLE
Add privacy and terms pages with footer links

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next"
 import { GeistSans } from 'geist/font/sans'
 import { ThemeProvider } from "@/components/theme-provider"
 import { Header } from "@/components/header"
+import Link from "next/link"
 import "./globals.css"
 import { SpeedInsights } from "@vercel/speed-insights/next"
 
@@ -17,6 +18,8 @@ export default function RootLayout({
 }: {
   children: React.ReactNode
 }) {
+  const currentYear = new Date().getFullYear()
+
   return (
     <html lang="en" suppressHydrationWarning>
       <body className={geist.className}>
@@ -29,9 +32,20 @@ export default function RootLayout({
           </a>
           <div className="min-h-screen bg-background text-foreground">
             <Header />
-            <main id="main-content" className="mx-auto max-w-3xl px-6 py-12">
-              {children}
-            </main>
+            <main id="main-content" className="mx-auto max-w-3xl px-6 py-12">{children}</main>
+            <footer className="border-t border-border">
+              <div className="mx-auto flex max-w-3xl flex-col gap-3 px-6 py-6 text-sm text-muted-foreground sm:flex-row sm:items-center sm:justify-between">
+                <p>{currentYear} Prabin Paudel. All rights reserved.</p>
+                <div className="flex items-center gap-4">
+                  <Link href="/privacy-policy" className="hover:text-foreground hover:underline">
+                    Privacy Policy
+                  </Link>
+                  <Link href="/terms-and-conditions" className="hover:text-foreground hover:underline">
+                    Terms & Conditions
+                  </Link>
+                </div>
+              </div>
+            </footer>
           </div>
           <SpeedInsights />
         </ThemeProvider>

--- a/app/privacy-policy/page.tsx
+++ b/app/privacy-policy/page.tsx
@@ -1,0 +1,58 @@
+import type { Metadata } from "next"
+import Link from "next/link"
+
+export const metadata: Metadata = {
+  title: "Privacy Policy | Prabin Paudel",
+  description: "Privacy policy for prabin194.com.np.",
+}
+
+export default function PrivacyPolicyPage() {
+  return (
+    <div className="space-y-10">
+      <section className="space-y-3">
+        <h1 className="text-4xl font-bold">Privacy Policy</h1>
+        <p className="text-sm text-muted-foreground">Last updated: March 5, 2026</p>
+      </section>
+
+      <section className="space-y-6 text-muted-foreground">
+        <div className="space-y-2">
+          <h2 className="text-xl font-semibold text-foreground">Overview</h2>
+          <p>
+            This website shares articles and project updates. It is designed to keep data collection as minimal as possible.
+          </p>
+        </div>
+
+        <div className="space-y-2">
+          <h2 className="text-xl font-semibold text-foreground">Information Collected</h2>
+          <p>
+            Personal information is not required to browse this site. If you contact me directly by email, the information
+            you provide is used only to respond to your message.
+          </p>
+        </div>
+
+        <div className="space-y-2">
+          <h2 className="text-xl font-semibold text-foreground">Cookies and Analytics</h2>
+          <p>
+            This site does not use advertising cookies. Basic performance monitoring may be used to keep the site stable and
+            fast, without building personal advertising profiles.
+          </p>
+        </div>
+
+        <div className="space-y-2">
+          <h2 className="text-xl font-semibold text-foreground">Third-Party Links</h2>
+          <p>
+            Pages may include links to other websites such as GitHub. Those websites have separate privacy policies and are
+            not controlled by this site.
+          </p>
+        </div>
+
+        <div className="space-y-2">
+          <h2 className="text-xl font-semibold text-foreground">Contact</h2>
+          <p>
+            For privacy-related questions, use the contact details on the <Link href="/about" className="text-primary hover:underline">About page</Link>.
+          </p>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/app/sitemap.xml/route.ts
+++ b/app/sitemap.xml/route.ts
@@ -8,7 +8,7 @@ const CONTENT_DIR = path.join(process.cwd(), "@content");
 type UrlEntry = { loc: string; lastmod?: string };
 
 function getStaticRoutes(): UrlEntry[] {
-  const routes = ["", "/about", "/blog", "/projects"];
+  const routes = ["", "/about", "/blog", "/projects", "/privacy-policy", "/terms-and-conditions"];
   return routes.map((r) => ({ loc: `${SITE_URL}${r}` }));
 }
 

--- a/app/terms-and-conditions/page.tsx
+++ b/app/terms-and-conditions/page.tsx
@@ -1,0 +1,66 @@
+import type { Metadata } from "next"
+import Link from "next/link"
+
+export const metadata: Metadata = {
+  title: "Terms and Conditions | Prabin Paudel",
+  description: "Terms and conditions for prabin194.com.np.",
+}
+
+export default function TermsAndConditionsPage() {
+  return (
+    <div className="space-y-10">
+      <section className="space-y-3">
+        <h1 className="text-4xl font-bold">Terms & Conditions</h1>
+        <p className="text-sm text-muted-foreground">Last updated: March 5, 2026</p>
+      </section>
+
+      <section className="space-y-6 text-muted-foreground">
+        <div className="space-y-2">
+          <h2 className="text-xl font-semibold text-foreground">Acceptance of Terms</h2>
+          <p>
+            By using this website, you agree to these terms and applicable laws.
+          </p>
+        </div>
+
+        <div className="space-y-2">
+          <h2 className="text-xl font-semibold text-foreground">Content Use</h2>
+          <p>
+            Unless stated otherwise, all original content on this site is owned by the site author. You may reference or
+            share content with proper credit and a link to the source.
+          </p>
+        </div>
+
+        <div className="space-y-2">
+          <h2 className="text-xl font-semibold text-foreground">No Warranty</h2>
+          <p>
+            Content is provided for general information only. While care is taken for accuracy, no guarantee is made that all
+            information is complete, current, or error-free.
+          </p>
+        </div>
+
+        <div className="space-y-2">
+          <h2 className="text-xl font-semibold text-foreground">Limitation of Liability</h2>
+          <p>
+            The site owner is not responsible for damages arising from use of this website, including reliance on content or
+            access to third-party links.
+          </p>
+        </div>
+
+        <div className="space-y-2">
+          <h2 className="text-xl font-semibold text-foreground">Changes to Terms</h2>
+          <p>
+            These terms may be updated periodically. Continued use of the website after updates means you accept the revised
+            terms.
+          </p>
+        </div>
+
+        <div className="space-y-2">
+          <h2 className="text-xl font-semibold text-foreground">Contact</h2>
+          <p>
+            Questions about these terms can be sent using the contact details on the <Link href="/about" className="text-primary hover:underline">About page</Link>.
+          </p>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/app/terms-of-conditions/page.tsx
+++ b/app/terms-of-conditions/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation"
+
+export default function TermsOfConditionsAliasPage() {
+  redirect("/terms-and-conditions")
+}


### PR DESCRIPTION
Summary
- add dedicated privacy policy and terms & conditions pages with metadata and content
- include linked footer in the layout plus updated sitemap entries to surface the new routes
- keep the old /terms-of-conditions URL redirecting to the new canonical route for continuity

Testing
- Not run (not requested)